### PR TITLE
Update TXTRecord API

### DIFF
--- a/examples/register.rs
+++ b/examples/register.rs
@@ -7,7 +7,7 @@ use dnssd_rs::txt::*;
 fn main() {
     println!("Registering service...");
     let mut txt = TXTRecord::new();
-    let _ = txt.set_value("s", "open");
+    let _ = txt.insert("s", Some("open"));
     let mut service = DNSServiceBuilder::new("_rust._tcp")
         .with_port(2048)
         .with_name("MyRustService")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ pub mod browser;
 pub mod register;
 pub mod txt;
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum DNSServiceError {
     /// Invalid input string
     InvalidString,

--- a/src/register.rs
+++ b/src/register.rs
@@ -180,7 +180,7 @@ impl DNSService {
             let c_name = c_name.as_ref();
             let service_type = CString::new(self.regtype.as_str()).map_err(|_| DNSServiceError::InvalidString)?;
             let (txt_record, txt_len) = match &mut self.txt {
-                Some(txt) => (txt.get_bytes_ptr(), txt.len()),
+                Some(txt) => (txt.raw_bytes_ptr(), txt.raw_bytes_len()),
                 None => (ptr::null(), 0), 
             };
             let result = DNSServiceRegister(&mut self.raw, 0, 0, c_name.map_or(ptr::null_mut(), |c| c.as_ptr()), service_type.as_ptr(), 
@@ -196,7 +196,7 @@ impl DNSService {
     pub fn update_txt_record(&mut self, mut txt: Option<TXTRecord>) -> Result<(), DNSServiceError> {
         unsafe {
             let (txt_record, txt_len) = match &mut txt {
-                Some(txt) => (txt.get_bytes_ptr(), txt.len()),
+                Some(txt) => (txt.raw_bytes_ptr(), txt.raw_bytes_len()),
                 None => (ptr::null(), 0), 
             };
             let result = DNSServiceUpdateRecord(self.raw, ptr::null_mut(), 0, txt_len, txt_record, 0);


### PR DESCRIPTION
- Stop taking `&mut self` where it's unnecessary.
- Support setting keys with null values.
- Use generics so we only need a single "set" method", which is now called `insert()`.
- Fix the length calculation in `insert()` so we don't treat a 257-byte value as if it were a 1-byte value.- Remove result types from methods where it doesn't make sense.
- Rename `len()` to `raw_bytes_len()` and add a new `len()` that returns the count of key/value pairs.
- Rename `get_bytes_ptr()` to `raw_bytes_ptr()`.
- Add method `raw_bytes()` that returns the raw bytes as a slice.