### PR TITLE
Fix inability to tell a service was a removal event

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astro-dnssd"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Jeremy Knope <jeremy@astropad.com>"]
 description = "Simple & safe DNS-SD wrapper"
 keywords = ["dns-sd", "dnssd", "bonjour", "zeroconf", "mdns"]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,25 +5,24 @@ trigger:
 
 strategy:
   matrix:
-    # windows-stable:
-    #   imageName: 'vs2017-win2016'
-    #   rustup_toolchain: stable
+    windows-stable:
+      imageName: 'windows-latest'
+      rustup_toolchain: stable
     mac-stable:
-      imageName: 'macos-10.15'
+      imageName: 'macos-latest'
       rustup_toolchain: stable
     linux-stable:
-      imageName: 'ubuntu-18.04'
+      imageName: 'ubuntu-latest'
       rustup_toolchain: stable
 
 pool:
   vmImage: $(imageName)
 
 steps:
-  # TODO: figure out how we can automate installing Bonjour SDK
-  - script: |
-      choco install bonjour
-    displayName: Install Windows dependencies
-    condition: eq( variables['Agent.OS'], 'Windows_NT' )
+#  - script: |
+#      choco install bonjour
+#    displayName: Install Windows dependencies
+#    condition: eq( variables['Agent.OS'], 'Windows_NT' )
   - script: |
       curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUSTUP_TOOLCHAIN
       echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"

--- a/examples/browse.rs
+++ b/examples/browse.rs
@@ -1,7 +1,7 @@
 use env_logger::Env;
 use log::{error, info};
 // use std::net::ToSocketAddrs;
-use astro_dnssd::{BrowseError, ServiceBrowserBuilder};
+use astro_dnssd::{BrowseError, ServiceBrowserBuilder, ServiceEventType};
 use std::io::ErrorKind;
 use std::time::Duration;
 
@@ -15,7 +15,11 @@ fn main() {
             loop {
                 match browser.recv_timeout(Duration::from_millis(500)) {
                     Ok(service) => {
-                        info!("Service found: {:?}", service);
+                        if service.event_type == ServiceEventType::Added {
+                            info!("Service found: {:?}", service);
+                        } else {
+                            info!("Service left: {}", service.hostname);
+                        }
                     }
                     Err(BrowseError::IoError(e)) if e.kind() == ErrorKind::TimedOut => {
                         std::thread::sleep(Duration::from_millis(100));

--- a/src/browse.rs
+++ b/src/browse.rs
@@ -1,7 +1,5 @@
 pub use crate::os::{BrowseError, ServiceBrowser};
 use std::collections::HashMap;
-// use std::io::Error as IoError;
-// use thiserror::Error;
 
 /// Service browsing result type
 pub type Result<T, E = BrowseError> = std::result::Result<T, E>;
@@ -11,7 +9,7 @@ pub trait ServiceBrowserTrait {
 }
 
 /// Type of service event from browser, if a service is being added or removed from network
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ServiceEventType {
     /// Service has been added to the network
     Added,

--- a/src/ffi/apple.rs
+++ b/src/ffi/apple.rs
@@ -8,7 +8,7 @@
 pub const kDNSServiceMaxServiceName: u32 = 64;
 pub const kDNSServiceMaxDomainName: u32 = 1009;
 pub const kDNSServiceInterfaceIndexAny: u32 = 0;
-pub const kDNSServiceProperty_DaemonVersion: &'static [u8; 14usize] = b"DaemonVersion\0";
+pub const kDNSServiceProperty_DaemonVersion: &[u8; 14usize] = b"DaemonVersion\0";
 pub type dnssd_sock_t = ::std::os::raw::c_int;
 pub type dispatch_queue_t = *mut dispatch_queue_s;
 #[repr(C)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,9 @@ mod non_blocking;
 mod os;
 mod register;
 
-pub use crate::browse::{BrowseError, Service, ServiceBrowser, ServiceBrowserBuilder};
+pub use crate::browse::{
+    BrowseError, Service, ServiceBrowser, ServiceBrowserBuilder, ServiceEventType,
+};
 pub use crate::os::{RegisteredDnsService, RegistrationError};
 pub use crate::register::DNSServiceBuilder;
 

--- a/src/non_blocking.rs
+++ b/src/non_blocking.rs
@@ -60,7 +60,7 @@ mod os {
                 std::ptr::null_mut(),
                 &mut timeout,
             );
-            Ok(libc::FD_ISSET(fd, &mut read_set))
+            Ok(libc::FD_ISSET(fd, &read_set))
         }
     }
 }

--- a/src/os/apple/register.rs
+++ b/src/os/apple/register.rs
@@ -129,7 +129,7 @@ impl Drop for ServiceRef {
             if !self.raw.is_null() {
                 trace!("Deallocating DNSServiceRef");
                 DNSServiceRefDeallocate(self.raw);
-                self.raw = std::ptr::null_mut();
+                self.raw = null_mut();
                 Box::from_raw(self.context);
             }
         }
@@ -170,7 +170,7 @@ pub fn register_service(service: DNSServiceBuilder) -> Result<RegisteredDnsServi
         let c_name = c_name.as_ref();
         let service_type =
             CString::new(service.regtype.as_str()).map_err(|_| RegistrationError::InvalidString)?;
-        let txt = service.txt.and_then(|h| Some(TXTRecord::from(h)));
+        let txt = service.txt.map(TXTRecord::from);
         let (txt_record, txt_len) = match &txt {
             Some(txt) => (txt.raw_bytes_ptr(), txt.raw_bytes_len()),
             None => (ptr::null(), 0),
@@ -184,7 +184,7 @@ pub fn register_service(service: DNSServiceBuilder) -> Result<RegisteredDnsServi
             &mut raw,
             0,
             0,
-            c_name.map_or(ptr::null_mut(), |c| c.as_ptr()),
+            c_name.map_or(null_mut(), |c| c.as_ptr()),
             service_type.as_ptr(),
             ptr::null(),
             ptr::null(),


### PR DESCRIPTION
ServiceEventType wasn't exposed so users couldn't tell that the service was a removal event vs add event.