### PR TITLE
fix(windows): Get hostname from SRV record instead of assembling it 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ libc = "0.2"
 pkg-config = "0.3.9"
 
 [dev-dependencies]
-env_logger = "0.10"
+env_logger = "0.11"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astro-dnssd"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Jeremy Knope <jeremy@astropad.com>"]
 description = "Simple & safe DNS-SD wrapper"
 keywords = ["dns-sd", "dnssd", "bonjour", "zeroconf", "mdns"]

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -3,8 +3,5 @@ use std::os::windows::ffi::OsStrExt;
 pub mod browse;
 pub mod register;
 pub fn to_utf16<S: AsRef<std::ffi::OsStr>>(s: S) -> Vec<u16> {
-    s.as_ref()
-        .encode_wide()
-        .chain(Some(0u16).into_iter())
-        .collect()
+    s.as_ref().encode_wide().chain(Some(0u16)).collect()
 }

--- a/src/os/windows/register.rs
+++ b/src/os/windows/register.rs
@@ -124,7 +124,7 @@ impl fmt::Debug for RegisteredDnsService {
 impl RegisteredDnsService {
     fn free_context(&mut self) {
         if !self.request.pQueryContext.is_null() {
-            unsafe { Box::from_raw(self.request.pQueryContext) };
+            _ = unsafe { Box::from_raw(self.request.pQueryContext as *mut SyncSender<u32>) };
             self.request.pQueryContext = null_mut();
         }
     }


### PR DESCRIPTION
The assemble approach produces incorrect `hostname` values for setups where the `hostname` doesn't match the computer's name.