### PR TITLE
feat: add support for Apple's libdns_sd.so on Linux

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -16,7 +16,10 @@ fn cfg_os_is(family: &str) -> bool {
 fn find_avahi_compat_dns_sd() {
     // on unix but not darwin link avahi compat
     if cfg_family_is("unix") && !(cfg_os_is("macos") || cfg_os_is("ios")) {
-        pkg_config::probe_library("avahi-compat-libdns_sd").unwrap();
+        if let Err(_) = pkg_config::probe_library("avahi-compat-libdns_sd") {
+            println!("cargo:warning=avahi-compat-libdns_sd not found via pkg-config, will just link against libdns_sd");
+            println!("cargo:rustc-link-lib=dns_sd");
+        }
     }
 }
 


### PR DESCRIPTION
This has been tested together with the mdns Yocto/OE package: https://git.openembedded.org/meta-openembedded/tree/meta-networking/recipes-protocols/mdns/mdns_2200.100.94.0.2.bb?h=7f3e41361272